### PR TITLE
fix(examples/multiple_versions): pin null provider to 0.11 compatible version

### DIFF
--- a/examples/multiple_versions/0.11/main.tf
+++ b/examples/multiple_versions/0.11/main.tf
@@ -1,5 +1,5 @@
 provider "null" {
-
+  version = "2.0.0"
 }
 
 resource "null_resource" "version" {


### PR DESCRIPTION
This PR fixes the `examples/multiple_versions` example and test by pinning the `null` provider to a version that is compatible with Terraform 0.11.