### PR TITLE
fix(auto-update): Only have a single update PR

### DIFF
--- a/scripts/mirror_terraform_releases.sh
+++ b/scripts/mirror_terraform_releases.sh
@@ -93,10 +93,10 @@ fi
 date="$(date --utc -I)"
 
 >&2 echo "New version information generated, committing"
-git checkout -b "auto-update-versions-$date"
+git checkout -b "auto-update-versions"
 git add "$VERSIONS_FILE"
 git commit -m "Auto updated Terraform versions $date"
-git push origin -u "auto-update-versions-$date"
+git push origin -u "auto-update-versions"
 
 if [ -n "${GITHUB_OUTPUT:-}" ]; then
     echo "has_changes=true" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
Multiple auto update PRs are created as a new branch is created per day and a PR is created per branch. This reduces the auto update script to use one branch, thus one PR will only be created.